### PR TITLE
add HiDPI texture/window ratio for MacOS

### DIFF
--- a/src/sdlui_helpers.cpp
+++ b/src/sdlui_helpers.cpp
@@ -40,7 +40,13 @@ void SDLUI_Init(SDL_Renderer *r, SDL_Window *w)
 	SDLUI_Core.renderer = r;
 	SDLUI_Core.window = w;
 	SDL_GetWindowSize(SDLUI_Core.window, &SDLUI_Core.window_width, &SDLUI_Core.window_height);
-
+    
+    // Managing High DPI texture to window ratio (MacOS)
+    i32 renderer_width, renderer_height;
+    SDL_GetRendererOutputSize(SDLUI_Core.renderer, &renderer_width, &renderer_height);
+    SDLUI_Core.texture_window_hdpi_ratio_x=(float)renderer_width/SDLUI_Core.window_width;
+    SDLUI_Core.texture_window_hdpi_ratio_y=(float)renderer_height/SDLUI_Core.window_height;
+    
 	SDLUI_Window_Collection.create();
 
 	SDLUI_Core.cursor_arrow = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
@@ -336,6 +342,11 @@ void SDLUI_WindowHandler()
 {
 	i32 mx, my, index = 0;
 	SDL_GetMouseState(&mx, &my);
+    #ifdef __APPLE__
+    mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+    my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+    #endif
+    
 	SDLUI_Control_Window *aw = SDLUI_Core.active_window;
 	static SDLUI_RESIZE_DIRECTION res_dir = SDLUI_RESIZE_NONE;
 

--- a/src/sdlui_render.cpp
+++ b/src/sdlui_render.cpp
@@ -549,6 +549,11 @@ void SDLUI_Render_Window(SDLUI_Control_Window *wnd)
 
 			i32 mx, my;
 			SDL_GetMouseState(&mx, &my);
+            #ifdef __APPLE__
+            mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+            my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+            #endif
+            
 			r = {wnd->x + wnd->w - 30, wnd->y, 30, 30};
 
 			if(wnd->has_close_button)

--- a/src/sdlui_structs.cpp
+++ b/src/sdlui_structs.cpp
@@ -283,6 +283,9 @@ struct __SDLUI_Core
 	SDL_Renderer *renderer;
 	i32 window_width;
 	i32 window_height;
+    float texture_window_hdpi_ratio_x;
+    float texture_window_hdpi_ratio_y;
+    
 	u8 mouse_current_frame[5] = {0};
 	u8 mouse_last_frame[5] = {0};
 	i32 mouse_wheel_y;

--- a/src/sdlui_usage.cpp
+++ b/src/sdlui_usage.cpp
@@ -16,6 +16,10 @@ bool SDLUI_Window(SDLUI_Control_Window *wnd)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
 
 		SDL_Rect r = {wnd->x, wnd->y, wnd->w, wnd->h};
 
@@ -81,7 +85,11 @@ bool SDLUI_Button(SDLUI_Control_Button *btn)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
-
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
+        
 		SDL_Rect r = {btn->x,btn->y,btn->w,btn->h};
 		if(SDLUI_PointInRect(r, mx, my))
 		{
@@ -118,6 +126,10 @@ bool SDLUI_SliderInt(SDLUI_Control_SliderInt *si)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
 
 		SDL_Rect r = {si->x,si->y,si->w,si->h};
 		if(SDLUI_PointInRect(r, mx, my))
@@ -175,6 +187,10 @@ bool SDLUI_CheckBox(SDLUI_Control_CheckBox *chk)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
 
 		i32 tex_w, tex_h;
 		SDL_QueryTexture(chk->tex_text, NULL, NULL, &tex_w, &tex_h);
@@ -205,6 +221,10 @@ bool SDLUI_ToggleButton(SDLUI_Control_ToggleButton *tb)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
 
 		i32 tex_w, tex_h;
 		SDL_QueryTexture(tb->tex_text, NULL, NULL, &tex_w, &tex_h);
@@ -237,6 +257,10 @@ bool SDLUI_RadioButton(SDLUI_Control_RadioButton *rb)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
 
 		i32 tex_w, tex_h;
 		SDL_QueryTexture(rb->tex_text, NULL, NULL, &tex_w, &tex_h);
@@ -289,6 +313,11 @@ bool SDLUI_TabContainer(SDLUI_Control_TabContainer *tbc)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
+        
 		SDL_Rect r = {tbc->x,tbc->y,tbc->w,tbc->bar_height};
 		SDL_Rect tab_r;
 		i32 offset = 0;
@@ -329,6 +358,11 @@ bool SDLUI_ScrollArea(SDLUI_Control_ScrollArea *sa)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
+        
 		SDL_Rect r, rv, rh;
 
 		r = {sa->x, sa->y, sa->w, sa->h};
@@ -494,6 +528,11 @@ bool SDLUI_List(SDLUI_Control_List *lst, const char *cur_item, i32 num_items, i3
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
+        
 		SDL_Rect r = {lst->scroll_area->x, lst->scroll_area->y, lst->scroll_area->client_width, lst->scroll_area->client_height};
 
 		if(SDLUI_PointInRect(r, mx, my) && cur_index == 0)
@@ -595,6 +634,10 @@ bool SDLUI_TextBox(SDLUI_Control_TextBox *tbx)
 	{
 		i32 mx, my;
 		SDL_GetMouseState(&mx, &my);
+        #ifdef __APPLE__
+        mx=mx*SDLUI_Core.texture_window_hdpi_ratio_x;
+        my=my*SDLUI_Core.texture_window_hdpi_ratio_y;
+        #endif
 
 		SDL_Rect r = {tbx->x,tbx->y,tbx->w,tbx->h};
 


### PR DESCRIPTION
This patch creates the ```SLDUI_Core.texture_window_hdpi_ratio_``` values initialised in ```SDLUI_Init```.
Then mutliplies all ```SDL_MouseState x&y``` by those factors to get the mouse on the correct place on HiDPI screens (for  Mac only)
It's not checking wether the window moves from a monitor to another though (I don't know how to do that). So no updates will be made if the ratio changes when moving the window to a different Monitor.